### PR TITLE
Fix Vue global build usage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { createApp } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js';
+const { createApp } = Vue;
 import Toolbar from './components/Toolbar.js';
 import MapEditor from './components/MapEditor.js';
 import SeatEditor from './components/SeatEditor.js';


### PR DESCRIPTION
## Summary
- remove ESM import of Vue and use global Vue build

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687397fc55408327bfd803af525369d0