### PR TITLE
Fix Vue imports

### DIFF
--- a/js/components/MapEditor.js
+++ b/js/components/MapEditor.js
@@ -1,4 +1,4 @@
-const { ref, reactive, watch, onMounted } = Vue;
+// Vue is loaded globally, so use the runtime APIs directly
 
 function pointInPolygon(point, vs) {
   let x = point.x, y = point.y;
@@ -22,14 +22,14 @@ export default {
   },
   emits: ['update:polygons', 'update:selectedPolygonId', 'update:selectedSeat'],
   setup(props, { emit }) {
-    const svgRef = ref(null);
-    const transform = reactive({ x: 0, y: 0, scale: 1 });
-    const drawing = reactive({ active: false, points: [] });
+    const svgRef = Vue.ref(null);
+    const transform = Vue.reactive({ x: 0, y: 0, scale: 1 });
+    const drawing = Vue.reactive({ active: false, points: [] });
 
-    const startPan = reactive({ active: false, x: 0, y: 0, tx: 0, ty: 0 });
+    const startPan = Vue.reactive({ active: false, x: 0, y: 0, tx: 0, ty: 0 });
 
-    const nextPolygonId = ref(1);
-    const nextSeatId = ref(1);
+    const nextPolygonId = Vue.ref(1);
+    const nextSeatId = Vue.ref(1);
 
     const onWheel = (e) => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- remove destructured Vue helpers in MapEditor component
- call Vue API using global `Vue.*` helpers

## Testing
- `node --check js/components/MapEditor.js`
- `node --check js/components/SeatEditor.js`
- `node --check js/components/Toolbar.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6873ad71ce5483279221ab63d4e93f66