### PR TITLE
Fix transform attribute quoting

### DIFF
--- a/js/components/MapEditor.js
+++ b/js/components/MapEditor.js
@@ -173,7 +173,7 @@ export default {
          @wheel="onWheel"
          @mousedown="onMouseDown" @mousemove="onMouseMove" @mouseup="onMouseUp"
          @click="onSvgClick" @dblclick="onDblClick">
-      <g :transform="\`translate(${transform.x},${transform.y}) scale(${transform.scale})\`">
+      <g :transform="'translate(' + transform.x + ',' + transform.y + ') scale(' + transform.scale + ')'">
         <g v-for="poly in polygons" :key="poly.id">
           <polygon
             :points="poly.points.map(p => \`${p.x},${p.y}\`).join(' ')"


### PR DESCRIPTION
## Summary
- use single quotes to build the `transform` attribute string

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6874ab9a65748327a0e331561225368f