### PR TITLE
Add App demo with background and initial seats

### DIFF
--- a/js/App.vue
+++ b/js/App.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="w-full h-full relative">
-    <SeatMapEditor class="w-full h-full" :background="bg" v-model:seats="seats" @save="saved = $event" />
-    <pre class="absolute bottom-2 left-2 bg-white text-xs p-2 rounded shadow max-w-xs max-h-40 overflow-auto" v-if="saved">{{ JSON.stringify(saved, null, 2) }}</pre>
+    <SeatMapEditor
+      class="w-full h-full"
+      :background="background"
+      v-model:seats="seats"
+      @save="handleSave"
+    />
+    <pre
+      v-if="saved"
+      class="absolute bottom-2 left-2 bg-white text-xs p-2 rounded shadow max-w-xs max-h-40 overflow-auto"
+    >{{ JSON.stringify(saved, null, 2) }}</pre>
   </div>
 </template>
 
@@ -9,7 +17,17 @@
 import { ref } from 'vue'
 import SeatMapEditor from './components/SeatMapEditor.vue'
 
-const bg = 'https://picsum.photos/800/600?random=1'
-const seats = ref([])
+const background =
+  'https://images.unsplash.com/photo-1501196354995-cbb51c65aaea?auto=format&fit=crop&w=800&q=80'
+
+const seats = ref([
+  { id: crypto.randomUUID(), label: '1', x: 120, y: 80 },
+  { id: crypto.randomUUID(), label: '2', x: 220, y: 160 }
+])
+
 const saved = ref(null)
+
+function handleSave(payload) {
+  saved.value = payload
+}
 </script>


### PR DESCRIPTION
## Summary
- provide demo App.vue with stadium background and example seats
- keep minimal index.html to mount the editor

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68761e4b5a7c832782764761bd6b040d